### PR TITLE
Numbers -> Numerical

### DIFF
--- a/exercise/1-Python-Pandas/1-a-Python.ipynb
+++ b/exercise/1-Python-Pandas/1-a-Python.ipynb
@@ -68,7 +68,7 @@
    "source": [
     "## Basic Data Types\n",
     "\n",
-    "- Number: integer, float, complex\n",
+    "- Numerical: integer, float, complex\n",
     "- String: `\"I'm a string\"`\n",
     "- Boolean: True, False\n",
     "- List: `[1, 2, 3]`\n",
@@ -81,7 +81,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Number"
+    "### Numerical"
    ]
   },
   {


### PR DESCRIPTION
As suggested, "Numbers" has been changed to "Numerical" to maintain a consistent singular nomenclature.